### PR TITLE
fix(converter): fixes the import of JSON modules

### DIFF
--- a/src/converter.ts
+++ b/src/converter.ts
@@ -270,6 +270,7 @@ export function createConverter(options?: ConverterOptions): Converter {
       // Remove 'use strict' from outputs.
       noImplicitUseStrict: true,
       experimentalDecorators: true,
+      resolveJsonModule: true,
       jsx: ts.JsxEmit.React,
       typeRoots: getTypeRoots(),
       // allowJs, checkJs and outDir are necessary to transpile .js files.


### PR DESCRIPTION
Allows the import of JSON modules in `tslab` or in modules imported to `tslab`.

Issues: https://github.com/yunabe/tslab/issues/43