### PR TITLE
bump zeromq to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "commander": "^6.2.0",
     "rollup": "^2.34.2",
     "semver": "^7.3.4",
-    "zeromq": "^6.0.0-beta.6"
+    "zeromq": "^6.0.0-beta.11"
   },
   "scripts": {
     "//": "experimental-vm-modules enables https://nodejs.org/docs/latest-v12.x/api/vm.html#vm_class_vm_sourcetextmodule",


### PR DESCRIPTION
tslab won't install for me on node LTS due to this error: https://github.com/zeromq/zeromq.js/issues/530

Fixed in this PR: https://github.com/zeromq/zeromq.js/pull/531

Bumping zeromq to latest via this PR. Thanks!